### PR TITLE
Add plausible analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,6 @@
 
 Use ``nimble genbook`` to generate the tutorials.
 
+## Analytics
+
+This website is tracking analytics with [plausible.io](plausible.io), a lightweight and open-source website analytics tool with no cookies and fully compliant with GDPR, CCPA and PECR. Analytics for this website are publicly available: <https://plausible.io/scinim.github.io%2Fgetting-started>. You can opt out from analytics tracking [with standard ad-blocking](https://plausible.io/docs/excluding) or typing [`localStorage.plausible_ignore=true`](https://plausible.io/docs/excluding-localstorage) in browser console.

--- a/book/head.mustache
+++ b/book/head.mustache
@@ -1,0 +1,1 @@
+<script defer data-domain="scinim.github.io/getting-started" src="https://plausible.io/js/plausible.js"></script>

--- a/book/head.mustache
+++ b/book/head.mustache
@@ -1,1 +1,0 @@
-<script defer data-domain="scinim.github.io/getting-started" src="https://plausible.io/js/plausible.js"></script>

--- a/getting_started.nim
+++ b/getting_started.nim
@@ -13,4 +13,5 @@ var book = newBookFromToc("SciNim Getting Started", "book"):
 
 
 book.git_repository_url = "https://github.com/SciNim/getting-started"
+book.plausible_analytics_url = "scinim.github.io/getting-started"
 nimibookCli(book)


### PR DESCRIPTION
this adds plausible analytics to this site (same as in [nimibook](https://github.com/pietroppeter/nimibook)). This is done through my plausible account which has currently plenty of views to use before reaching next threshold (10K over all sites). If needed in the future I will upgrade to 100k as part of my planned effort to sponsor Nim, but I guess it will take a bit of time. Even though analytics is provided through my account, I have made them publicly visible and if anyone of the maintainers is interested I can invite them to join (so that you would be able to change settings).