### PR TITLE
Fix docs actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,36 +8,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: "gh-pages"
       - name: "install_nim"
         id: install_nim
         uses: iffy/install-nim@v3
-      - name: Set CI config github
-        run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-      - name: Fetch
-        run: git fetch
-      - name: Rebase
-        run: git rebase -Xours origin/main
-      - run: nimble install -y
+      - name: install dependencies
+        run: nimble install -y
       - name: Compile Book
         run: nim c getting_started.nim
       - name: Init Book
         run: ./getting_started init
       - name: Build Book
         run: ./getting_started build
-      - name: Commit files
-        run: |
-          echo ${{ github.ref }}
-          git add -f docs
-          git commit -m "CI: Automated build push" -a | exit 0
-      - name: Force push to destination branch
-        uses: ad-m/github-push-action@v0.5.0
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: gh-pages
-          force: true
-          directory: ./docs
-
+          publish_dir: docs


### PR DESCRIPTION
As experienced in nimibook (e.g. https://github.com/pietroppeter/nimibook/issues/30), current gh-actions for commiting and pushing new docs in gh-pages has problems when files are added and removed (since it is based on a rebase command).
I tested https://github.com/peaceiris/actions-gh-pages in nimibook and it works well.

Changes needed on top of merging this:
- (optional) remove gh-pages branch before merging. The action will create again the branch and the commit history will be much clearer: https://github.com/pietroppeter/nimibook/commits/gh-pages
- change settings for Github pages to use root folder instead of docs folder (but still use gh-pages). (do this after removing gh-pages and merging).
