### PR TITLE
don't fail if docs doesn't exist

### DIFF
--- a/.github/workflows/pr_preview.yml
+++ b/.github/workflows/pr_preview.yml
@@ -60,7 +60,7 @@ jobs:
             });
             var fs = require('fs');
             fs.writeFileSync('${{github.workspace}}/docs.zip', Buffer.from(download.data));
-      - run: rm -r docs
+      - run: rm -rf docs
       - run: unzip -d docs/ docs.zip
 
       - run: echo Deploy Alias = ${{ env.GITHUB_SHA_SHORT }}


### PR DESCRIPTION
Don't know if it was because of the reworking of the CI scripts or something but we failed because `docs/` didn't exist. The `-f` option should just ignore it if that's the case.

