### PR TITLE
add workflow that runs tests once a month

### DIFF
--- a/.github/workflows/periodic_test.yml
+++ b/.github/workflows/periodic_test.yml
@@ -1,0 +1,22 @@
+name: periodic test
+
+on:
+  schedule:
+    # Run every month the 20th when the clock is 13:00 UTC
+    - cron: '0 13 20 * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: pip install scipy numpy
+      - name: "install_nim"
+        id: install_nim
+        uses: iffy/install-nim@v4.1.1
+      - run: nimble install -y
+      - name: GenBook
+        run: nimble genbook


### PR DESCRIPTION
This way we will be able to catch when our code stops working. Before, we only knew when someone made a PR.